### PR TITLE
Fixes wrong import path

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -3,7 +3,8 @@ package auth
 import (
 	"errors"
 	"fmt"
-	"github.com/AKosterin/pogo/auth/google"
+
+	"github.com/pkmngo-odi/pogo/auth/google"
 	"github.com/pkmngo-odi/pogo/auth/ptc"
 )
 


### PR DESCRIPTION
There is an issue with the import path that would fetch the AKosterin
fork of the repo instead of the repo itself, leading to duplicated
binaries in $GOPATH , and some import path problems when vendoring
pkmngo-odi/pogo (because the fork is not in the source tree)
